### PR TITLE
Fix build against latest

### DIFF
--- a/jenkins_latest_elastic
+++ b/jenkins_latest_elastic
@@ -9,12 +9,25 @@ node {
             checkout scm
         }
         stage("Build") {
-            //Specific Job that tests against the latest version of Elasticsearch
-            withMaven(maven: "Basis", mavenLocalRepo: "$JENKINS_HOME/.m2/repository") {
-              sh "mvn -Delasticsearch.version=\$(curl -s http://search.maven.org/solrsearch/select?q=g:%22org.elasticsearch%22+AND+a:%22elasticsearch%22 | sed -n 's/.*latestVersion\":\"\\([0-9]\\.[0-9]\\.[0-9]\\).*/\\1/p') clean verify"
+            env.OUR_ELASTIC_VERSION = sh (
+                script: "grep -oP \"<elasticsearch.version>\\K.+(?=</elasticsearch.version>)\" pom.xml",
+                returnStdout: true
+            ).trim()
+            env.LATEST_ELASTIC_VERSION = sh (
+                script: "curl -sL http://search.maven.org/solrsearch/select?q=g:%22org.elasticsearch%22+AND+a:%22elasticsearch%22 | jq -r .response.docs[0].latestVersion",
+                returnStdout: true
+            ).trim()
+            if (env.OUR_ELASTIC_VERSION == env.LATEST_ELASTIC_VERSION) {
+                echo "No change in ElasticSearch version, skipping build."
+            } else if (env.LATEST_ELASTIC_VERSION ==~ /^(\d+\.)?(\d+\.)?(\d+)$/) {
+                echo "ElasticSearch version ${env.LATEST_ELASTIC_VERSION} is not official semver, skipping build."
+            } else {
+                withMaven(maven: "Basis", mavenLocalRepo: "$JENKINS_HOME/.m2/repository") {
+                    sh "mvn -Delasticsearch.version=${env.LATEST_ELASTIC_VERSION} clean verify"
+                }
+                slack(true)
             }
         }
-        slack(true)
     } catch (e) {
         currentBuild.result = "FAILED"
         slack(false)

--- a/jenkins_latest_elastic
+++ b/jenkins_latest_elastic
@@ -20,12 +20,12 @@ node {
             if (env.OUR_ELASTIC_VERSION == env.LATEST_ELASTIC_VERSION) {
                 echo "No change in ElasticSearch version, skipping build."
             } else if (env.LATEST_ELASTIC_VERSION ==~ /^(\d+\.)?(\d+\.)?(\d+)$/) {
-                echo "ElasticSearch version ${env.LATEST_ELASTIC_VERSION} is not official semver, skipping build."
-            } else {
                 withMaven(maven: "Basis", mavenLocalRepo: "$JENKINS_HOME/.m2/repository") {
                     sh "mvn -Delasticsearch.version=${env.LATEST_ELASTIC_VERSION} clean verify"
                 }
                 slack(true)
+            } else {
+                echo "ElasticSearch version ${env.LATEST_ELASTIC_VERSION} is not official semver, skipping build."
             }
         }
     } catch (e) {

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -87,12 +87,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>4.1.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <scope>test</scope>

--- a/plugin/src/test/java/com/rosette/elasticsearch/CategoriesProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/CategoriesProcessorTest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class CategoriesProcessorTest extends ESSingleNodeTestCase {
 
     public void testCategories() throws Exception {
-        CategoriesProcessor processor = new CategoriesProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "category");
+        CategoriesProcessor processor = new CategoriesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "category");
 
         String inputText = "The people played lots of sports like soccer and hockey. The score was very high. Touchdown!";
 

--- a/plugin/src/test/java/com/rosette/elasticsearch/EntitiesProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/EntitiesProcessorTest.java
@@ -33,7 +33,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
             + "magnificent women in comedy.";
 
     public void testEntities() throws Exception {
-        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "entities", false, false, LanguageCode.ENGLISH, false);
+        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "entities", false, false, LanguageCode.ENGLISH, false);
 
         Map<String, Object> document = new HashMap<>();
         document.put("text", INPUTTEXT);
@@ -52,7 +52,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
     }
 
     public void testOffsets() throws Exception {
-        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "entities", true, false, LanguageCode.ENGLISH, false);
+        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "entities", true, false, LanguageCode.ENGLISH, false);
 
         Map<String, Object> document = new HashMap<>();
         document.put("text", INPUTTEXT);
@@ -70,7 +70,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
     }
 
     public void testSentiment() throws Exception {
-        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "entities", false, false, LanguageCode.ENGLISH, true);
+        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "entities", false, false, LanguageCode.ENGLISH, true);
 
         Map<String, Object> document = new HashMap<>();
         document.put("text", INPUTTEXT);
@@ -87,7 +87,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
     }
 
     public void testTranslate() throws Exception {
-        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "entities", false, true, LanguageCode.KOREAN, false);
+        EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "entities", false, true, LanguageCode.KOREAN, false);
 
         Map<String, Object> document = new HashMap<>();
         document.put("text", INPUTTEXT);

--- a/plugin/src/test/java/com/rosette/elasticsearch/LanguageProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/LanguageProcessorTest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class LanguageProcessorTest extends ESSingleNodeTestCase {
 
     public void testLangId() throws Exception {
-        LanguageProcessor processor = new LanguageProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "language");
+        LanguageProcessor processor = new LanguageProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "language");
 
         String inputText = "This is a very English document. It should be identified as English.";
 

--- a/plugin/src/test/java/com/rosette/elasticsearch/NameTranslationProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/NameTranslationProcessorTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 public class NameTranslationProcessorTest extends ESSingleNodeTestCase {
 
     public void testTranslateToEnglish() throws Exception {
-        NameTranslationProcessor processor = new NameTranslationProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "translation", LanguageCode.ENGLISH, ISO15924.Latn, "PERSON", LanguageCode.RUSSIAN, ISO15924.Cyrl, LanguageCode.UNKNOWN);
+        NameTranslationProcessor processor = new NameTranslationProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "translation", LanguageCode.ENGLISH, ISO15924.Latn, "PERSON", LanguageCode.RUSSIAN, ISO15924.Cyrl, LanguageCode.UNKNOWN);
 
         String inputText = "Владимир Путин";
 

--- a/plugin/src/test/java/com/rosette/elasticsearch/RosetteAbstractProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/RosetteAbstractProcessorTest.java
@@ -39,7 +39,7 @@ public class RosetteAbstractProcessorTest extends ESSingleNodeTestCase {
     }
 
     public void testEmptyField() throws Exception {
-        MockProcessor processor = new MockProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "target");
+        MockProcessor processor = new MockProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "target");
 
         //Process document with an empty "text" field
         Map<String, Object> document = new HashMap<>();
@@ -52,7 +52,7 @@ public class RosetteAbstractProcessorTest extends ESSingleNodeTestCase {
 
     @Test(expected = ElasticsearchException.class)
     public void testOverwrite() throws Exception {
-        MockProcessor processor = new MockProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "target");
+        MockProcessor processor = new MockProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "target");
 
         //Process document with a value already in the target field
         Map<String, Object> document = new HashMap<>();

--- a/plugin/src/test/java/com/rosette/elasticsearch/SentimentProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/SentimentProcessorTest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class SentimentProcessorTest extends ESSingleNodeTestCase {
 
     public void testSentiment() throws Exception {
-        SentimentProcessor processor = new SentimentProcessor(new RosetteApiWrapper(), randomAsciiOfLength(10), "text", "sentiment");
+        SentimentProcessor processor = new SentimentProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10), "text", "sentiment");
 
         String inputText = "I love this sentence so much I want to marry it!";
 


### PR DESCRIPTION
- `randomAsciiOfLength` disappeared without deprecation from ES
- jenkins latest should only build official versions (semver), not -alpha, etc