### PR TITLE
SUPPO-1041: fix the pluging to work with ES 6.3.0+

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
-# uses '|| true' to make sure that even if there is an error,
+code=0
+set -x
+
+# uses '|| code=$?' to make sure that even if there is an error,
 # the maven build continues and stops the docker image
-curl -XPUT "localhost:$1/_ingest/pipeline/rosapi?pretty" -d'
+# the exit codes will be appended to the output file for later verification
+
+curl -fsSL -H "Content-Type: application/json" -XPUT "localhost:$1/_ingest/pipeline/rosapi?pretty" -d'
 {
   "processors": [
     {
@@ -52,10 +57,10 @@ curl -XPUT "localhost:$1/_ingest/pipeline/rosapi?pretty" -d'
     }
   ]
 }
-' || true
+' || ((code++))
 
 #Pipeline without categories since it only supports English
-curl -XPUT "localhost:$1/_ingest/pipeline/rosapi_jpn?pretty" -d'
+curl -fsSL -H "Content-Type: application/json" -XPUT "localhost:$1/_ingest/pipeline/rosapi_jpn?pretty" -d'
 {
   "processors": [
     {
@@ -99,9 +104,9 @@ curl -XPUT "localhost:$1/_ingest/pipeline/rosapi_jpn?pretty" -d'
     }
   ]
 }
-' || true
+' || ((code++))
 
-curl -XPUT "localhost:$1/test_idx?pretty" -d'
+curl -fsSL -H "Content-Type: application/json" -XPUT "localhost:$1/test_idx?pretty" -d'
 {
   "mappings": {
     "rosette": {
@@ -117,30 +122,30 @@ curl -XPUT "localhost:$1/test_idx?pretty" -d'
     }
   }
 }
-' || true
+' || ((code++))
 
-curl -XPUT "localhost:$1/test_idx/rosette/1?pretty&refresh=true&pipeline=rosapi" -d'
+curl -fsSL -H "Content-Type: application/json" -XPUT "localhost:$1/test_idx/rosette/1?pretty&refresh=true&pipeline=rosapi" -d'
 {
   "text": "Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t be more pleased with the new all-female Ghostbusters cast, telling The Hollywood Reporter, “The Aykroyd family is delighted by this inheritance of the Ghostbusters torch by these most magnificent women in comedy.”"
 }
-' || true
+' || ((code++))
 
-curl -XPUT "localhost:$1/test_idx/rosette/2?pretty&refresh=true&pipeline=rosapi_jpn" -d'
+curl -fsSL -H "Content-Type: application/json" -XPUT "localhost:$1/test_idx/rosette/2?pretty&refresh=true&pipeline=rosapi_jpn" -d'
 {
   "text": "バングラデシュ政府、ロヒンギャ難民の島への移動を計画 \nバングラデシュ政府、ロヒンギャ難民の島への移動を計画\n\nテンガール・チャール島は約10年前に、メグナ川の堆積土で形成され、高潮の際には数十センチの水に囲まれてしまう。道路や堤防などは築かれておらず、島を記載する地図はあまりない。\n\n約30キロ西には60万人が住むハティｱ島があり、現在の難民キャンプからの移動には9時間かかる。\n\nある地元政府関係者はAFP通信に対し、テンガール・チャール島について、「島に行けるのは冬のみで、海賊たちの隠れ家になっている」と語った。島を洪水から守るため植樹が行われているが、完了するまでには少なくとも10年がかかるという。同関係者は、「モンスーンの季節には完全に水浸しになってしまう」と話し、「あそこに住まわせるというのは、ひどいアイデアだ」と指摘した。\n\nImage caption 移住が計画されているテンガール・チャール島はハティア（Hatiya）島の近くにある\n\nミャンマーでは、ロヒンギャの人々は国境を接するバングラデシュからの不法移民として扱われており、国籍の取得ができずにいる。\n\n"
 }
-' || true
+' || ((code++))
 
-curl -XPUT "localhost:$1/test_idx/rosette/3?pretty&refresh=true&pipeline=rosapi" -d'
+curl -fsSL -H "Content-Type: application/json" -XPUT "localhost:$1/test_idx/rosette/3?pretty&refresh=true&pipeline=rosapi" -d'
 {
   "text" : "Vladimir Vladimirovich Nabokov was a Russian-American novelist and entomologist. His first nine novels were in Russian, and he achieved international prominence after he began writing English prose.",
   "name" : "Vladimir Nabokov"
 }
-' || true
+' || ((code++))
 
 sleep 3
 
-curl -XPOST "localhost:$1/test_idx/_search?pretty" -d'
+curl -fsSL -H "Content-Type: application/json" -XPOST "localhost:$1/test_idx/_search?pretty" -d'
 {
   "query": {
     "constant_score" : {
@@ -150,4 +155,7 @@ curl -XPOST "localhost:$1/test_idx/_search?pretty" -d'
     }
   }
 }
-' || true
+' || ((code++))
+
+set +x
+echo "exit: $code"

--- a/docker/verify.sh
+++ b/docker/verify.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-if grep -E -i 'exception|"failed":[1-9]' $1; then
-    echo "Test query failed! See $1 for details. Exiting...";
-    exit 1;
+if [[ "$(tail -1 "$1" 2>/dev/null)" !=  "exit: 0" ]] ; then
+    echo "There are test failures. Exiting..."
+    exit 1
+fi
+
+if grep -E -i 'exception|"failed":[1-9]' "$1" ; then
+    echo "Test query failed! See $1 for details. Exiting..."
+    exit 1
 fi

--- a/plugin/src/main/assemblies/plugin.xml
+++ b/plugin/src/main/assemblies/plugin.xml
@@ -8,18 +8,15 @@
     <files>
         <file>
             <source>${project.basedir}/src/main/resources/plugin-descriptor.properties</source>
-            <outputDirectory>elasticsearch</outputDirectory>
             <filtered>true</filtered>
         </file>
         <file>
             <source>${project.basedir}/src/main/resources/plugin-security.policy</source>
-            <outputDirectory>elasticsearch</outputDirectory>
             <filtered>false</filtered>
         </file>
     </files>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>elasticsearch</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>false</useTransitiveFiltering>
             <excludes>


### PR DESCRIPTION
- update per https://github.com/elastic/elasticsearch/pull/28589
- update curl calls with application/json type which seems to be required now
- update docker test script to not swallow detectable errors