### PR TITLE
use a custom HttpClient that uses standard java system properties

### DIFF
--- a/plugin/src/main/java/com/rosette/elasticsearch/RosetteApiWrapper.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/RosetteApiWrapper.java
@@ -19,12 +19,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.Loggers;
 
 import com.basistech.rosette.api.HttpRosetteAPI;
-import org.elasticsearch.common.logging.Loggers;
 
 //Configures and holds on to the shared Rosette API client
 public final class RosetteApiWrapper {
@@ -69,12 +73,20 @@ public final class RosetteApiWrapper {
         }
 
         HttpRosetteAPI.Builder clientBuilder = new HttpRosetteAPI.Builder();
-        clientBuilder.key(apiKey).additionalHeader("X-RosetteAPI-App", APP_HEADER);
+        clientBuilder.httpClient(createHttpClient()).key(apiKey).additionalHeader("X-RosetteAPI-App", APP_HEADER);
         if (!Strings.isNullOrEmpty(altUrl)) {
             LOGGER.info("Using alternative URL for Rosette API at : " + altUrl);
             clientBuilder.url(altUrl);
         }
         httpRosetteAPI = clientBuilder.build();
+    }
+
+    private CloseableHttpClient createHttpClient() {
+        HttpClientBuilder builder = HttpClients.custom();
+        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+        builder.setConnectionManager(cm);
+        builder.useSystemProperties();
+        return builder.build();
     }
 
     public HttpRosetteAPI getHttpRosetteAPI() {


### PR DESCRIPTION
This PR builds a custom HttpClient with `useSystemProperties()`, and then inject it into rosette java lib.

Doing so, it lets to configure a proxy to access https://api.rosette.com in Elasticsearch, with this config: 
`export ES_JAVA_OPTS="-Dhttps.proxyHost=my-proxy -Dhttps.proxyPort=3128"`