### PR TITLE
7.13.0 release fixes and Sonar

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -104,8 +104,12 @@
             <groupId>org.elasticsearch.test</groupId>
             <artifactId>framework</artifactId>
             <scope>test</scope>
-            <!-- dependency convergence error with org.apache.httpcomponents:httpclient:jar:4.5.2 -->
             <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <!-- dependency convergence error with org.apache.httpcomponents:httpclient:jar:4.5.2 -->
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -348,11 +348,6 @@
                                     <include>com.basistech:common-api-jackson</include>
                                     <include>com.fasterxml.jackson.core:*</include>
                                 </includes>
-                                <!-- This blob clears the shade plugin warning, but breaks the runtime classpath -->
-                                <!-- <excludes>
-                                    <artifact>*:*</artifact>
-                                    <exclude>META-INF/MANIFEST.MF</exclude>
-                                </excludes> -->
                             </artifactSet>
                             <relocations>
                                 <relocation>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -39,14 +39,14 @@
         </site>
     </distributionManagement>
     <properties>
-        <bnd-maven-plugin.version>5.2.0</bnd-maven-plugin.version>
+        <bnd-maven-plugin.version>5.3.0</bnd-maven-plugin.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <commons-lang3.version>3.11</commons-lang3.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <findbugs.version>3.0.2</findbugs.version>
         <joda-time.version>2.10.10</joda-time.version>
         <jopt-simple.version>5.0.4</jopt-simple.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
-        <mockserver.version>5.11.1</mockserver.version>
+        <mockserver.version>5.11.2</mockserver.version>
         <mockserver.baseurl>/rest/worker/v1/</mockserver.baseurl>
         <hamcrest.version>2.2</hamcrest.version>
         <slf4j-ext.version>1.7.30</slf4j-ext.version>
@@ -135,6 +135,11 @@
             <version>${mockserver.version}</version>
             <scope>test</scope>
             <exclusions>
+                <!-- mockserver 5.11.2 references two version of swagger-core -->
+                <exclusion>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-core</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>commons-codec</groupId>
                     <artifactId>commons-codec</artifactId>

--- a/plugin/src/main/java/com/rosette/elasticsearch/CategoriesProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/CategoriesProcessor.java
@@ -31,6 +31,8 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
 
+import static com.basistech.rosette.api.common.AbstractRosetteAPI.CATEGORIES_SERVICE_PATH;
+
 public class CategoriesProcessor extends RosetteAbstractProcessor {
 
     public static final String TYPE = "ros_categories";
@@ -51,8 +53,7 @@ public class CategoriesProcessor extends RosetteAbstractProcessor {
         try {
             // RosApi client binding's Jackson needs elevated privilege
             response = AccessController.doPrivileged((PrivilegedAction<CategoriesResponse>) () ->
-                    rosAPI.getHttpRosetteAPI().perform(HttpRosetteAPI.CATEGORIES_SERVICE_PATH, request,
-                            CategoriesResponse.class)
+                    rosAPI.getHttpRosetteAPI().perform(CATEGORIES_SERVICE_PATH, request, CategoriesResponse.class)
             );
         } catch (HttpRosetteAPIException ex) {
             LOGGER.error(ex.getErrorResponse().getMessage());

--- a/plugin/src/main/java/com/rosette/elasticsearch/CategoriesProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/CategoriesProcessor.java
@@ -15,7 +15,6 @@
 */
 package com.rosette.elasticsearch;
 
-import com.basistech.rosette.api.HttpRosetteAPI;
 import com.basistech.rosette.api.HttpRosetteAPIException;
 import com.basistech.rosette.apimodel.CategoriesOptions;
 import com.basistech.rosette.apimodel.CategoriesResponse;

--- a/plugin/src/main/java/com/rosette/elasticsearch/EntitiesProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/EntitiesProcessor.java
@@ -41,6 +41,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.basistech.rosette.api.common.AbstractRosetteAPI.ENTITIES_SERVICE_PATH;
+import static com.basistech.rosette.api.common.AbstractRosetteAPI.NAME_TRANSLATION_SERVICE_PATH;
+import static com.basistech.rosette.api.common.AbstractRosetteAPI.SENTIMENT_SERVICE_PATH;
+
 public class EntitiesProcessor extends RosetteAbstractProcessor {
 
     public static final String TYPE = "ros_entities";
@@ -74,14 +78,14 @@ public class EntitiesProcessor extends RosetteAbstractProcessor {
                 DocumentRequest<SentimentOptions> sentrequest = DocumentRequest.<SentimentOptions>builder()
                         .content(inputText).build();
                 adm = AccessController.doPrivileged((PrivilegedAction<AnnotatedText>) () ->
-                        rosAPI.getHttpRosetteAPI().perform(AbstractRosetteAPI.SENTIMENT_SERVICE_PATH, sentrequest)
+                        rosAPI.getHttpRosetteAPI().perform(SENTIMENT_SERVICE_PATH, sentrequest)
                 );
             } else {
                 //REX
                 DocumentRequest<EntitiesOptions> entityrequest = DocumentRequest.<EntitiesOptions>builder()
                         .content(inputText).build();
                 adm = AccessController.doPrivileged((PrivilegedAction<AnnotatedText>) () ->
-                        rosAPI.getHttpRosetteAPI().perform(AbstractRosetteAPI.ENTITIES_SERVICE_PATH, entityrequest)
+                        rosAPI.getHttpRosetteAPI().perform(ENTITIES_SERVICE_PATH, entityrequest)
                 );
             }
         } catch (HttpRosetteAPIException ex) {
@@ -163,7 +167,7 @@ public class EntitiesProcessor extends RosetteAbstractProcessor {
             NameTranslationResponse rntresponse;
             try {
                 rntresponse = AccessController.doPrivileged((PrivilegedAction<NameTranslationResponse>) () ->
-                        rosAPI.getHttpRosetteAPI().perform(AbstractRosetteAPI.NAME_TRANSLATION_SERVICE_PATH, rntrequest,
+                        rosAPI.getHttpRosetteAPI().perform(NAME_TRANSLATION_SERVICE_PATH, rntrequest,
                                 NameTranslationResponse.class)
                 );
             } catch (HttpRosetteAPIException ex) {

--- a/plugin/src/main/java/com/rosette/elasticsearch/EntitiesProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/EntitiesProcessor.java
@@ -16,7 +16,6 @@
 package com.rosette.elasticsearch;
 
 import com.basistech.rosette.api.HttpRosetteAPIException;
-import com.basistech.rosette.api.common.AbstractRosetteAPI;
 import com.basistech.rosette.apimodel.DocumentRequest;
 import com.basistech.rosette.apimodel.EntitiesOptions;
 import com.basistech.rosette.apimodel.NameTranslationRequest;
@@ -155,9 +154,9 @@ public class EntitiesProcessor extends RosetteAbstractProcessor {
 
         //RNT
         if (doTranslate
-                && (type.equalsIgnoreCase("PERSON")
-                || type.equalsIgnoreCase("LOCATION")
-                || type.equalsIgnoreCase("ORGANIZATION"))) {
+                && ("PERSON".equalsIgnoreCase(type)
+                || "LOCATION".equalsIgnoreCase(type)
+                || "ORGANIZATION".equalsIgnoreCase(type))) {
             NameTranslationRequest rntrequest = NameTranslationRequest.builder()
                     .name(headMention)
                     .targetLanguage(translateLanguage)

--- a/plugin/src/main/java/com/rosette/elasticsearch/LanguageProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/LanguageProcessor.java
@@ -31,6 +31,8 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
 
+import static com.basistech.rosette.api.common.AbstractRosetteAPI.LANGUAGE_SERVICE_PATH;
+
 public class LanguageProcessor extends RosetteAbstractProcessor {
 
     public static final String TYPE = "ros_language";
@@ -50,7 +52,7 @@ public class LanguageProcessor extends RosetteAbstractProcessor {
         try {
             // RosApi client binding's Jackson needs elevated privilege
             response = AccessController.doPrivileged((PrivilegedAction<LanguageResponse>) () ->
-                    rosAPI.getHttpRosetteAPI().perform(HttpRosetteAPI.LANGUAGE_SERVICE_PATH, request,
+                    rosAPI.getHttpRosetteAPI().perform(LANGUAGE_SERVICE_PATH, request,
                             LanguageResponse.class)
             );
         } catch (HttpRosetteAPIException ex) {

--- a/plugin/src/main/java/com/rosette/elasticsearch/LanguageProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/LanguageProcessor.java
@@ -15,7 +15,6 @@
 */
 package com.rosette.elasticsearch;
 
-import com.basistech.rosette.api.HttpRosetteAPI;
 import com.basistech.rosette.api.HttpRosetteAPIException;
 import com.basistech.rosette.apimodel.DocumentRequest;
 import com.basistech.rosette.apimodel.LanguageOptions;

--- a/plugin/src/main/java/com/rosette/elasticsearch/RosetteAbstractProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/RosetteAbstractProcessor.java
@@ -29,7 +29,7 @@ public abstract class RosetteAbstractProcessor extends AbstractProcessor {
     protected String inputField;
     protected String targetField;
     protected RosetteApiWrapper rosAPI;
-    protected final String type;
+    protected final String processorType;
 
     RosetteAbstractProcessor(RosetteApiWrapper rosAPI, String tag, String description, String processorType,
                              String inputField, String targetField) {
@@ -37,14 +37,14 @@ public abstract class RosetteAbstractProcessor extends AbstractProcessor {
         this.inputField = inputField;
         this.targetField = targetField;
         this.rosAPI = rosAPI;
-        this.type = processorType;
+        this.processorType = processorType;
     }
 
     @Override
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         if (ingestDocument.hasField(targetField)) {
             throw new ElasticsearchException("Document already contains data in target field for this ingest "
-                    + "processor: " + type);
+                    + "processor: " + processorType);
         }
         if (!ingestDocument.hasField(inputField)) {
             //Do nothing
@@ -69,7 +69,7 @@ public abstract class RosetteAbstractProcessor extends AbstractProcessor {
 
     @Override
     public String getType() {
-        return this.type;
+        return this.processorType;
     }
 
     /**

--- a/plugin/src/main/java/com/rosette/elasticsearch/RosetteApiWrapper.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/RosetteApiWrapper.java
@@ -76,7 +76,7 @@ public final class RosetteApiWrapper {
         HttpRosetteAPI.Builder clientBuilder = new HttpRosetteAPI.Builder();
         clientBuilder.key(apiKey).additionalHeader("X-RosetteAPI-App", APP_HEADER);
         if (!Strings.isNullOrEmpty(altUrl)) {
-            LOGGER.info("Using alternative URL for Rosette API at : " + altUrl);
+            LOGGER.info("Using alternative URL for Rosette API at : {} ", altUrl);
             clientBuilder.url(altUrl);
         }
         httpRosetteAPI = clientBuilder.build();

--- a/plugin/src/main/java/com/rosette/elasticsearch/SentimentProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/SentimentProcessor.java
@@ -32,6 +32,8 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
 
+import static com.basistech.rosette.api.common.AbstractRosetteAPI.SENTIMENT_SERVICE_PATH;
+
 public class SentimentProcessor extends RosetteAbstractProcessor {
 
     public static final String TYPE = "ros_sentiment";
@@ -53,7 +55,7 @@ public class SentimentProcessor extends RosetteAbstractProcessor {
         try {
             // RosApi client binding's Jackson needs elevated privilege
             response = AccessController.doPrivileged((PrivilegedAction<SentimentResponse>) () ->
-                    rosAPI.getHttpRosetteAPI().perform(HttpRosetteAPI.SENTIMENT_SERVICE_PATH, request,
+                    rosAPI.getHttpRosetteAPI().perform(SENTIMENT_SERVICE_PATH, request,
                             SentimentResponse.class)
             );
         } catch (HttpRosetteAPIException ex) {

--- a/plugin/src/main/java/com/rosette/elasticsearch/SentimentProcessor.java
+++ b/plugin/src/main/java/com/rosette/elasticsearch/SentimentProcessor.java
@@ -15,7 +15,6 @@
 */
 package com.rosette.elasticsearch;
 
-import com.basistech.rosette.api.HttpRosetteAPI;
 import com.basistech.rosette.api.HttpRosetteAPIException;
 import com.basistech.rosette.apimodel.DocumentRequest;
 import com.basistech.rosette.apimodel.SentimentOptions;

--- a/plugin/src/test/java/com/rosette/elasticsearch/CategoriesProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/CategoriesProcessorTest.java
@@ -20,12 +20,14 @@ import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class CategoriesProcessorTest extends ESSingleNodeTestCase {
 
+    @Test
     public void testCategories() throws Exception {
         CategoriesProcessor processor = new CategoriesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "category");

--- a/plugin/src/test/java/com/rosette/elasticsearch/EntitiesProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/EntitiesProcessorTest.java
@@ -21,6 +21,7 @@ import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.hamcrest.Matchers;
 import org.hamcrest.MatcherAssert;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +34,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
             + "Reporter, “The Aykroyd family is delighted by this inheritance of the Ghostbusters torch by these "
             + "most magnificent women in comedy.";
 
+    @Test
     public void testEntities() throws Exception {
         EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "entities", false, false,
@@ -54,6 +56,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
         MatcherAssert.assertThat(entity.get("offsets"), Matchers.nullValue());
     }
 
+    @Test
     public void testOffsets() throws Exception {
         EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "entities", true, false,
@@ -74,6 +77,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
         MatcherAssert.assertThat(entity.get("translation"), Matchers.nullValue());
     }
 
+    @Test
     public void testSentiment() throws Exception {
         EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "entities", false, false,
@@ -93,6 +97,7 @@ public class EntitiesProcessorTest extends ESSingleNodeTestCase {
         MatcherAssert.assertThat(entity.get("offsets"), Matchers.nullValue());
     }
 
+    @Test
     public void testTranslate() throws Exception {
         EntitiesProcessor processor = new EntitiesProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "entities", false, true,

--- a/plugin/src/test/java/com/rosette/elasticsearch/LanguageProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/LanguageProcessorTest.java
@@ -20,12 +20,14 @@ import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class LanguageProcessorTest extends ESSingleNodeTestCase {
 
+    @Test
     public void testLangId() throws Exception {
         LanguageProcessor processor = new LanguageProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "language");

--- a/plugin/src/test/java/com/rosette/elasticsearch/NameTranslationProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/NameTranslationProcessorTest.java
@@ -22,12 +22,14 @@ import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class NameTranslationProcessorTest extends ESSingleNodeTestCase {
 
+    @Test
     public void testTranslateToEnglish() throws Exception {
         NameTranslationProcessor processor = new NameTranslationProcessor(new RosetteApiWrapper(),
                 randomUnicodeOfLength(10), "description", "text", "translation",

--- a/plugin/src/test/java/com/rosette/elasticsearch/RosetteAbstractProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/RosetteAbstractProcessorTest.java
@@ -39,6 +39,7 @@ public class RosetteAbstractProcessorTest extends ESSingleNodeTestCase {
         }
     }
 
+    @Test
     public void testEmptyField() throws Exception {
         MockProcessor processor = new MockProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "target");

--- a/plugin/src/test/java/com/rosette/elasticsearch/RosetteTextAnalysisPluginIT.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/RosetteTextAnalysisPluginIT.java
@@ -49,9 +49,9 @@ import java.util.Map;
 public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
 
     @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
+                .put(super.nodeSettings(nodeOrdinal, otherSettings))
                 .put(RosetteTextAnalysisPlugin.ROSETTE_API_KEY.getKey(), System.getProperty("rosette.api.key", ""))
                 .build();
     }

--- a/plugin/src/test/java/com/rosette/elasticsearch/RosetteTextAnalysisPluginIT.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/RosetteTextAnalysisPluginIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -61,6 +62,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
         return Collections.singleton(RosetteTextAnalysisPlugin.class);
     }
 
+    @Test
     public void testPluginIsLoaded() throws Exception {
         NodesInfoResponse response = client().admin().cluster().prepareNodesInfo()
                 .addMetric(NodesInfoRequest.Metric.PLUGINS.metricName()).get();
@@ -77,6 +79,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
     }
 
     //Tests the language processor
+    @Test
     public void testLanguage() throws Exception {
 
         String inputText = "This is a very English document. It should be identified as English.";
@@ -88,6 +91,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
                 .get(LanguageProcessor.Parameters.TARGET_FIELD.defaultValue), Matchers.equalTo("eng"));
     }
 
+    @Test
     public void testCategories() throws Exception {
 
         String inputText = "The people played lots of sports like soccer and hockey. The score was very high. "
@@ -100,6 +104,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
                 .get(CategoriesProcessor.Parameters.TARGET_FIELD.defaultValue), Matchers.equalTo("SPORTS"));
     }
 
+    @Test
     public void testSentiment() throws Exception {
 
         String inputText = "I love this sentence so much I want to marry it!";
@@ -111,6 +116,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
                 .get(SentimentProcessor.Parameters.TARGET_FIELD.defaultValue), Matchers.equalTo("pos"));
     }
 
+    @Test
     public void testTranslateToEnglish() throws Exception {
 
         String inputText = "Владимир Путин";
@@ -123,6 +129,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
                 Matchers.equalTo("Vladimir Putin"));
     }
 
+    @Test
     public void testTranslateFromEnglish() throws Exception {
         String inputText = "Vladimir Putin";
 
@@ -134,6 +141,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
                 Matchers.equalTo("Владимир Путин"));
     }
 
+    @Test
     public void testEntities() throws Exception {
 
         String inputText = "Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t "
@@ -151,6 +159,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
         MatcherAssert.assertThat(entity.get("mention"), Matchers.equalTo("Original Ghostbuster"));
     }
 
+    @Test
     public void testEntitiesWithSentiment() throws Exception {
 
         String inputText = "Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t "
@@ -170,6 +179,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
     }
 
     //Test that all (or most) of the processors work together
+    @Test
     public void testAll() throws Exception {
 
         String inputText = "Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t "
@@ -204,7 +214,7 @@ public class RosetteTextAnalysisPluginIT extends ESIntegTestCase {
         IndexResponse indexResponse = client().prepareIndex("test", "test").setPipeline(pipelineName)
                 .setSource(XContentFactory.jsonBuilder().startObject().field("text", inputText)
                         .endObject()).get();
-        assertTrue("Failed to index document correctly", indexResponse.status().equals(RestStatus.CREATED));
+        assertEquals("Failed to index document correctly", RestStatus.CREATED, indexResponse.status());
         //Force index refresh
         refresh("test");
 

--- a/plugin/src/test/java/com/rosette/elasticsearch/SentimentProcessorTest.java
+++ b/plugin/src/test/java/com/rosette/elasticsearch/SentimentProcessorTest.java
@@ -20,12 +20,14 @@ import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class SentimentProcessorTest extends ESSingleNodeTestCase {
 
+    @Test
     public void testSentiment() throws Exception {
         SentimentProcessor processor = new SentimentProcessor(new RosetteApiWrapper(), randomUnicodeOfLength(10),
                 "description", "text", "sentiment");

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,10 @@
         <bt.compile.target>${jdk.version}</bt.compile.target>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <elasticsearch.version>7.13.0</elasticsearch.version>
-        <log4j.version>2.14.0</log4j.version>
+        <log4j.version>2.14.1</log4j.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
         <rosette.api.binding.version>1.18.0</rosette.api.binding.version>
     </properties>
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
-        <version>7.0.1</version>
+        <version>8.1.0</version>
         <relativePath />
     </parent>
     <inceptionYear>2017</inceptionYear>
@@ -45,7 +45,7 @@
         <bt.compile.source>${jdk.version}</bt.compile.source>
         <bt.compile.target>${jdk.version}</bt.compile.target>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
-        <elasticsearch.version>7.12.1</elasticsearch.version>
+        <elasticsearch.version>7.13.0</elasticsearch.version>
         <log4j.version>2.14.0</log4j.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -82,6 +82,12 @@
                 <groupId>org.elasticsearch.test</groupId>
                 <artifactId>framework</artifactId>
                 <version>${elasticsearch.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
**7.13 Issues**
- Dependency convergence error with `commons-lang3`
- Signature change in `ESIntegTestCase.nodeSettings`

**Sonar Issues**
- Removed commented out code from pom.
- Service paths now referenced thru `AbstractRosetteAPI`
- String equality test order
- Renamed `type` to `processorType` in `RosetteAbstractProcessor` to avoid confusion with `TYPE` declared in the sub-classes.
- `LOGGER` no longer concatenates strings.
- `@Test` annotations added where appropriate